### PR TITLE
Removing PHP 7+ return value typehint

### DIFF
--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -48,7 +48,7 @@ class Validator
         }
         $groupsRaw = $config->get('groups');
 
-        $groups = array_map(static function (array $groupRaw): Group {
+        $groups = array_map(static function (array $groupRaw) {
             return new Group($groupRaw['name'], $groupRaw['match']);
         }, $groupsRaw);
         $config->set('groups', $groups);


### PR DESCRIPTION
This package claims to be good for PHP >=5.5 so it cannot include PHP 7 only syntax.